### PR TITLE
add button for deleting request

### DIFF
--- a/mitm_proxy/src/mitm_proxy.rs
+++ b/mitm_proxy/src/mitm_proxy.rs
@@ -250,6 +250,7 @@ impl MitmProxy {
     }
 
     pub fn render_right_panel(&mut self, ui: &mut egui::Ui, i: usize) {
+        if i > self.requests.len() - 1 { return } 
         Grid::new("controls").show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.selectable_value(
@@ -292,16 +293,16 @@ impl MitmProxy {
         }
         if let Some(i) = self.state.selected_request {
             ui.columns(2, |columns| {
-                // needs to run before call to table_ui() because table_ui() might change self.state.selected_request
-                // if request is removed
+                ScrollArea::both()
+                    .id_source("requests_table")
+                    .show(&mut columns[0], |ui| self.table_ui(ui));
+
                 ScrollArea::vertical()
                     .id_source("request_details")
                     .show(&mut columns[1], |ui| {
                         self.render_right_panel(ui, i);
                     });
-                ScrollArea::both()
-                    .id_source("requests_table")
-                    .show(&mut columns[0], |ui| self.table_ui(ui));
+                
             })
         } else {
             ScrollArea::vertical()

--- a/mitm_proxy/src/requests.rs
+++ b/mitm_proxy/src/requests.rs
@@ -2,6 +2,7 @@ use eframe::egui::{self};
 use egui_extras::TableRow;
 use proxyapi::{*, hyper::Method};
 
+#[derive(Clone)]
 pub struct Details;
 
 #[derive(PartialEq)]
@@ -16,6 +17,8 @@ impl Default for InfoOptions {
         InfoOptions::Request
     }
 }
+
+#[derive(Clone)]
 pub struct RequestInfo {
     request: Option<ProxiedRequest>,
     response: Option<ProxiedResponse>,

--- a/proxyapi/src/proxy_handler.rs
+++ b/proxyapi/src/proxy_handler.rs
@@ -59,7 +59,7 @@ impl ProxyHandler {
 #[async_trait]
 impl HttpHandler for ProxyHandler {
     async fn handle_request(&mut self, _ctx: &HttpContext, mut req: Request<Body>, ) -> RequestResponse {
-        println!("request{:?}\n", req);
+        //println!("request{:?}\n", req);
         let mut body_mut = req.body_mut();
         let body_bytes = to_bytes(&mut body_mut).await.unwrap_or_default();
         *body_mut = Body::from(body_bytes.clone()); // Replacing the potentially mutated body with a reference to the entire contents
@@ -78,7 +78,7 @@ impl HttpHandler for ProxyHandler {
     }
 
     async fn handle_response(&mut self, _ctx: &HttpContext, mut res: Response<Body>) -> Response<Body> {
-        println!("res: {:?}\n\n", res);
+        //println!("res: {:?}\n\n", res);
         let mut body_mut = res.body_mut();
         let body_bytes = to_bytes(&mut body_mut).await.unwrap_or_default();
         *body_mut = Body::from(body_bytes.clone()); // Replacing the potentially mutated body with a reference to the entire contents


### PR DESCRIPTION
Should solve: #8 
The commit adds an extra button per request that let's the user remove the request. 

A couple things:
Because the rows per request are generated by iterating over the `vector` of `MitmProxy.requests` and we want to remove an entry from that `vector` while iterating over it, I had to copy the `vector` and iterate over the copy so that I could change the `MitmProxy.requests` freely. Not sure if this is the best approach, but works as of now. 

Also the order of how the different panels and columns are rendered had to be changed because otherwise `render_right_panel` would cause an index out of bounds error if a request got deleted in the call to `self.table_ui` beforehand. That's because it would try to render the right panel for a request that was deleted.
Maybe we could also do it like this to make sure that every call to `self.render_right_panel()` always has the latest version of `self.requests`:
```rust
ui.columns(2, |columns| {
            ScrollArea::both()
                .id_source("requests_table")
                .show(&mut columns[0], |ui| self.table_ui(ui));

            if let Some(i) = self.state.selected_request {
                ScrollArea::vertical()
                    .id_source("request_details")
                    .show(&mut columns[1], |ui| {
                        self.render_right_panel(ui, i);
                    });
            }
        })
```
 But then the sizing of the columns looks weird when start up of the application.

Let me know what you think.