### PR TITLE
Add colors to text of method

### DIFF
--- a/mitm_proxy/src/requests.rs
+++ b/mitm_proxy/src/requests.rs
@@ -1,4 +1,7 @@
-use eframe::egui::{self};
+use eframe::{
+    egui::{self},
+    epaint::Color32,
+};
 use egui_extras::TableRow;
 use proxyapi::{*, hyper::Method};
 
@@ -109,7 +112,20 @@ impl RequestInfo {
         });
 
         row.col(|ui| {
-            ui.label(req.method().to_string());
+            let method = req.method();
+            let color = match *method {
+                Method::OPTIONS => Color32::GRAY,
+                Method::GET => Color32::GREEN,
+                Method::POST => Color32::BLUE,
+                Method::PUT => Color32::LIGHT_BLUE,
+                Method::DELETE => Color32::RED,
+                Method::HEAD => Color32::YELLOW,
+                Method::TRACE => Color32::BROWN,
+                Method::CONNECT => Color32::GOLD,
+                Method::PATCH => Color32::DARK_BLUE,
+                _ => Color32::DARK_GRAY,
+            };
+            ui.colored_label(color, req.method().to_string());
         });
 
         row.col(|ui| {

--- a/mitm_proxy/src/requests.rs
+++ b/mitm_proxy/src/requests.rs
@@ -1,5 +1,5 @@
 use eframe::{
-    egui::{self},
+    egui::{self, Visuals},
     epaint::Color32,
 };
 use egui_extras::TableRow;
@@ -113,19 +113,8 @@ impl RequestInfo {
 
         row.col(|ui| {
             let method = req.method();
-            let color = match *method {
-                Method::OPTIONS => Color32::GRAY,
-                Method::GET => Color32::GREEN,
-                Method::POST => Color32::BLUE,
-                Method::PUT => Color32::LIGHT_BLUE,
-                Method::DELETE => Color32::RED,
-                Method::HEAD => Color32::YELLOW,
-                Method::TRACE => Color32::BROWN,
-                Method::CONNECT => Color32::GOLD,
-                Method::PATCH => Color32::DARK_BLUE,
-                _ => Color32::DARK_GRAY,
-            };
-            ui.colored_label(color, req.method().to_string());
+            let color = Self::get_method_color(&method, ui.visuals());
+            ui.colored_label(color, method.to_string());
         });
 
         row.col(|ui| {
@@ -139,5 +128,31 @@ impl RequestInfo {
         row.col(|ui| {
             ui.label(time.to_string());
         });
+    }
+
+    fn get_method_color(method: &Method, visuals: &Visuals) -> Color32 {
+        if visuals.dark_mode {
+            match *method {
+                Method::POST => Color32::from_rgb(73, 204, 144),
+                Method::GET => Color32::from_rgb(97, 175, 254),
+                Method::PUT => Color32::from_rgb(252, 161, 48),
+                Method::DELETE => Color32::from_rgb(249, 62, 62),
+                Method::OPTIONS => Color32::from_rgb(13, 90, 167),
+                Method::HEAD => Color32::from_rgb(144, 18, 254),
+                Method::PATCH => Color32::from_rgb(80, 227, 194),
+                _ => Color32::LIGHT_GRAY,
+            }
+        } else {
+            match *method {
+                Method::POST => Color32::from_rgb(72, 203, 144),
+                Method::GET => Color32::from_rgb(42, 105, 167),
+                Method::PUT => Color32::from_rgb(213, 157, 88),
+                Method::DELETE => Color32::from_rgb(200, 50, 50),
+                Method::OPTIONS => Color32::from_rgb(36, 89, 143),
+                Method::HEAD => Color32::from_rgb(140, 63, 207),
+                Method::PATCH => Color32::from_rgb(92, 214, 188),
+                _ => Color32::DARK_GRAY,
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes: #32 

Note:

- The texted is colored instead of background.
- color used might not be good selection

# source for color

- [swagger light theme](https://github.com/swagger-api/swagger-ui/blob/b0ab56187915677d99b3dc28120a9286aacdedc2/src/style/_variables.scss#L46)
- [swagger dark theme](https://github.com/Amoenus/SwaggerDark/blob/b6fa2536da4e60b3fa15fa5e62eaac668dbc2a21/SwaggerDark.css#L471) 

## Dark mode

![image](https://user-images.githubusercontent.com/26397224/226090879-a1660267-8633-49c2-b550-742639ee8b5d.png)


## Light mode

![image](https://user-images.githubusercontent.com/26397224/226090912-77aa419b-0c62-4078-82f8-8b3a8de66da0.png)


